### PR TITLE
[WIP] Allow customizable static bindings

### DIFF
--- a/src/main/java/com/opal/creator/ClassMember.java
+++ b/src/main/java/com/opal/creator/ClassMember.java
@@ -49,6 +49,8 @@ public class ClassMember {
 	private Trinary myInverseAccessor = Trinary.UNKNOWN;
 	private String myInverseAccessorMethodName;
 	private Trinary myNullAllowed = Trinary.UNKNOWN;
+	
+	private String myStaticBindingsQuery;
 
 	private String myValidationMethodName;
 	private String myValidationMethodClassName;
@@ -352,6 +354,14 @@ public class ClassMember {
 	
 	public void setNullAllowed(boolean argNullable) {
 		myNullAllowed = Trinary.valueOf(argNullable);
+	}
+	
+	public String getStaticBindingsQuery() {
+		return myStaticBindingsQuery;
+	}
+	
+	public void setStaticBindingsQuery(String argStaticBindingsQuery) {
+		myStaticBindingsQuery = argStaticBindingsQuery;
 	}
 	
 	/* package */ boolean isUnique(MappedClass argMC) {

--- a/src/main/java/com/opal/creator/Column.java
+++ b/src/main/java/com/opal/creator/Column.java
@@ -1,6 +1,8 @@
 package com.opal.creator;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
+
 import org.w3c.dom.Node;
 
 import com.siliconage.util.Trinary;
@@ -118,6 +120,11 @@ public class Column extends OpalXMLElement {
 			lclCM.setNullAllowed(false);
 		}
 		
+		String lclStaticBindingsForString = getAttributeValue("StaticBindingsFor");
+		if (StringUtils.isNotBlank(lclStaticBindingsForString)) {
+			lclCM.setStaticBindingsQuery(lclStaticBindingsForString);
+		}
+		
 		String lclComputedString = getAttributeValue("Computed");
 		if (lclComputedString == null) {
 			/* Nothing */
@@ -142,7 +149,6 @@ public class Column extends OpalXMLElement {
 		} else {
 			throw new IllegalStateException("Illegal value \"" + lclComputedString + "\" for Computed attribute.");
 		}
-		return;
 	}
 	
 	@Override

--- a/src/main/java/com/opal/creator/MappedClass.java
+++ b/src/main/java/com/opal/creator/MappedClass.java
@@ -172,7 +172,7 @@ public class MappedClass {
 	private boolean myGetAll;
 	private boolean myDependent;
 	private boolean myAssociation;
-	private List<String> myStaticBindingList;
+	private List<StaticBinding> myStaticBindingList;
 	
 	private PolymorphicData myPolymorphicData;
 	private boolean mySuperclassKeyResolved = false;
@@ -1006,8 +1006,11 @@ public class MappedClass {
 				/* TODO:  This fails when the name of the variable differs from the code used (like when it starts with a number
 				and needs to have an underscore prepended to make a valid Java identifier. */
 				
-				for (String lclCode : getStaticBindingList()) {
-					lclBW.println("\tpublic static final " + getInterfaceClassName() + ' ' + Mapping.convertToJavaIdentifier(lclCode) + "() { return getInstance().forCode(\"" + lclCode + "\"); }");
+				for (StaticBinding lclStaticBinding : getStaticBindingList()) {
+					String lclMemberName = lclStaticBinding.memberName();
+					String lclCode = lclStaticBinding.code();
+					
+					lclBW.println("\tpublic static final " + getInterfaceClassName() + ' ' + Mapping.convertToJavaIdentifier(lclCode).toUpperCase() + "() { return getInstance().for" + lclMemberName + "(\"" + lclCode + "\"); }");
 				}
 				lclBW.println();
 			}
@@ -5016,11 +5019,11 @@ public class MappedClass {
 		return myGetAll;
 	}
 	
-	public List<String> getStaticBindingList() {
+	public List<StaticBinding> getStaticBindingList() {
 		return myStaticBindingList;
 	}
 	
-	public void setStaticBindings(ArrayList<String> argStaticBindingList) {
+	public void setStaticBindings(List<StaticBinding> argStaticBindingList) {
 		myStaticBindingList = argStaticBindingList;
 	}
 	

--- a/src/main/java/com/opal/creator/StaticBinding.java
+++ b/src/main/java/com/opal/creator/StaticBinding.java
@@ -1,0 +1,6 @@
+package com.opal.creator;
+
+/* package */ record StaticBinding(
+	String memberName,
+	String code
+) {}

--- a/src/main/java/com/opal/creator/XMLCreator.java
+++ b/src/main/java/com/opal/creator/XMLCreator.java
@@ -21,7 +21,7 @@ public class XMLCreator {
 
 	/* These member variables store the database configuration information that is passed in via the command-line.  Similar
 	 * data can be provided via the <Database> element in the configuration file, but it is preferred to pass via the
-	 * command-line for security reasons (as the configuration file is often checked into a repository.
+	 * command-line for security reasons (as the configuration file is often checked into a repository).
 	 * 
 	 * The <Database> element will take priority over anything passed in on the command line.
 	 */


### PR DESCRIPTION
Fixes #9 (in a slightly different manner than I listed on that ticket).

Example:
```xml
<Mapping Table="Org">
	<Column Name="short_name" StaticBindingsFor="id &lt;= 1000" />
</Mapping>
```

This will only work if the column has a mapped unique index. (In this way, the example above is bad.) If the column doesn't have a mapped unique index, I expect that the static binding factory methods will generate but not compile. There's probably a better way to handle or at least enforce this rule; suggestions and improvements are welcome.