### PR TITLE
Handle a missing JavaClass member more gracefully

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	
 	<groupId>com.opal</groupId>
 	<artifactId>opal</artifactId>
-	<version>2.1.0</version>
+	<version>2.2.0</version>
 	
 	<properties>
 		<maven.compiler.source>21</maven.compiler.source>

--- a/src/main/java/com/opal/types/JavaClass.java
+++ b/src/main/java/com/opal/types/JavaClass.java
@@ -6,23 +6,18 @@ import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.reflect.ConstructorUtils;
 
 public class JavaClass<T> implements StringSerializable, Comparable<JavaClass<?>> {
-
+	private static final org.slf4j.Logger ourLogger = org.slf4j.LoggerFactory.getLogger(JavaClass.class.getName());
+	
 	private final String myClassName;
 	private final Class<T> myClass;
 
 	@SuppressWarnings("unchecked")
-	public JavaClass(String argClassName) {
+	protected JavaClass(String argClassName) throws ClassNotFoundException {
 		super();
 		
 		myClassName = Validate.notNull(argClassName);
 		
-		Class<T> lclClass;
-		try {
-			lclClass = (Class<T>) Class.forName(argClassName);
-		} catch (ClassNotFoundException lclE) {
-			throw new IllegalArgumentException("Could not find class " + argClassName, lclE);
-		}
-		myClass = lclClass;
+		myClass = (Class<T>) Class.forName(argClassName); // may throw ClassNotFoundException
 	}
 
 	public String getClassName() {
@@ -60,7 +55,12 @@ public class JavaClass<T> implements StringSerializable, Comparable<JavaClass<?>
 	}
 	
 	public static <U> JavaClass<U> fromSerializedString(String argClassName) {
-		return new JavaClass<>(argClassName);
+		try {
+			return new JavaClass<>(argClassName);
+		} catch (ClassNotFoundException lclE) {
+			ourLogger.warn("Couldn't find {}", argClassName);
+			return null;
+		}
 	}
 	
 	@Override

--- a/src/main/java/com/opal/types/SingletonJavaClass.java
+++ b/src/main/java/com/opal/types/SingletonJavaClass.java
@@ -7,15 +7,17 @@ import java.lang.reflect.Modifier;
 import org.apache.commons.lang3.Validate;
 
 public class SingletonJavaClass<T> extends JavaClass<T> {
+	private static final org.slf4j.Logger ourLogger = org.slf4j.LoggerFactory.getLogger(SingletonJavaClass.class.getName());
+	
 	private final Method myInstanceAccessor;
 	
-	protected SingletonJavaClass(String argClassName) {
+	protected SingletonJavaClass(String argClassName) throws ClassNotFoundException {
 		super(argClassName);
 		
 		myInstanceAccessor = findInstanceAccessor(null);
 	}
 	
-	protected SingletonJavaClass(String argClassName, String argInstanceAccessorName) {
+	protected SingletonJavaClass(String argClassName, String argInstanceAccessorName) throws ClassNotFoundException {
 		super(argClassName);
 		
 		myInstanceAccessor = findInstanceAccessor(Validate.notNull(argInstanceAccessorName, "Could not find instance accessor '" + argInstanceAccessorName + "' for " + argClassName));
@@ -76,7 +78,12 @@ public class SingletonJavaClass<T> extends JavaClass<T> {
 	}
 	
 	public static <U> SingletonJavaClass<U> fromSerializedString(String argClassName) {
-		return new SingletonJavaClass<>(argClassName);
+		try {
+			return new SingletonJavaClass<>(argClassName);
+		} catch (ClassNotFoundException lclE) {
+			ourLogger.warn("Couldn't find {}", argClassName);
+			return null;
+		}
 	}
 	
 	@Override


### PR DESCRIPTION
If an opal references a nonexistent `JavaClass`, currently, noisy exceptions are thrown. This makes it hard, or even impossible, to test new classes in a shared database situation, since a development environment needs to access them for testing, while a production environment doesn't have the new code and thus chokes, often prevent normal activities on the production environment.

This PR changes the factory methods to return `null` if the class is missing. This can still lead to problems in production (if we try to actually do something with the class), but at least the opals can be loaded, which improves the situations we've encountered so far.